### PR TITLE
Quick patch - allowing `_mrange` to filter the mm indices

### DIFF
--- a/src/obsolete/O3.jl
+++ b/src/obsolete/O3.jl
@@ -92,7 +92,7 @@ the same length such that `sum(mm) == 0`
 Base.sum(cc::CartesianIndex) = sum(cc.I)
 _mrange(L::Integer, ll) = _mrange(Val{L}(), ll)
 
-function _mrange(::Val{L}, ll; ll_filter = ll -> iseven(sum(ll)), mm_filter = mm -> abs(sum(mm)) <= L) where {L}
+function _mrange(::Val{L}, ll; ll_filter = ll -> iseven(sum(ll)+L), mm_filter = mm -> abs(sum(mm)) <= L) where {L}
    if !ll_filter(ll)
 	   return MRange{L, N, Tuple}(ll, ())
    end

--- a/test/test_obsolete_o3.jl
+++ b/test/test_obsolete_o3.jl
@@ -101,6 +101,7 @@ println()
 Lmax = 4
 basis = RYlmBasis(Lmax)
 for ntest = 1:30
+   local θ
    x = @SVector rand(3)
    θ = rand() * 2pi
    Q = RotXYZ(0, 0, θ)


### PR DESCRIPTION
This PR tries to resolve #8. But if the changes here do not make sense and/or contradicts the basic logic of this package, it can be abandoned at any time.