### PR TITLE
Change the format for returning an empty basis.

### DIFF
--- a/src/O3.jl
+++ b/src/O3.jl
@@ -296,7 +296,7 @@ function _coupling_coeffs(L::Int64, ll::SVector{N, Int64}, nn::SVector{N, Int64}
     r = length(Lset)
     T = L == 0 ? Float64 : SVector{2L+1,Float64}
     if r == 0 
-        return zeros(T, 1, 1), zeros(T, 1, 1), [zeros(Int,N)], [zeros(Int,N)]
+        return zeros(T, 0, 1), [zeros(Int,N)] # no valid coupling, return empty array
     else 
         MMmat, size_m = m_generate(nn,ll,L;flag=flag) # classes of m's
         FMatrix=zeros(T, r, length(MMmat)) # Matrix containing f(m,i)

--- a/src/O3.jl
+++ b/src/O3.jl
@@ -296,7 +296,7 @@ function _coupling_coeffs(L::Int64, ll::SVector{N, Int64}, nn::SVector{N, Int64}
     r = length(Lset)
     T = L == 0 ? Float64 : SVector{2L+1,Float64}
     if r == 0 
-        return zeros(T, 0, 1), [zeros(Int,N)] # no valid coupling, return empty array
+        return zeros(T, 0, 0), [] # no valid coupling, return empty array
     else 
         MMmat, size_m = m_generate(nn,ll,L;flag=flag) # classes of m's
         FMatrix=zeros(T, r, length(MMmat)) # Matrix containing f(m,i)


### PR DESCRIPTION
This PR is to give the "correct" return when no coupling is found for certain (nn,ll)'s. 

This would be a prerequisite for quickly fixing the ACEpot issue below (unless we want to integrate ET very soon):

https://github.com/ACEsuit/ACEpotentials.jl/issues/299